### PR TITLE
chore: bumps gradle version to fix build issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,12 +54,12 @@ android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   namespace "expo.modules.nativefonts"


### PR DESCRIPTION
## Description of changes

Android builds on EAS were failing due to the following error:

```
Execution failed for task ':bittingz-expo-native-fonts:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.
```

Updating jvm target to `VERSION_17` worked locally and solves https://github.com/gitn00b1337/expo-native-fonts/issues/4
 